### PR TITLE
made link-scanner recursive and much more comprehensive

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,8 @@ for link in links_to_make:
         last_backlink = new_backlink_block
 
     #Actually creating the backlink
-    new_block = page.children.add_alias(client.get_block(link[1]))
+    url_in_backlink = client.get_block(link[1]).get_browseable_url()
+    new_block = page.children.add_new(TextBlock, title="[{}]({})".format(link[0], url_in_backlink))
     print(f"    created backlink from {link[2]} to {link[0]}")
 
 print(f"Finished.")

--- a/app.py
+++ b/app.py
@@ -52,65 +52,53 @@ print(f" loading collection {cv.parent.title}:{cv.name}")
 
 # Define recursive function that parses the database: (IMPORTANT NOTE: This will parse all pages that are linked from pages in the database, so the effect of this script will go beyond justthe target database)
 
-def recursive_pass(x, last_page_visited = None):
+def recursive_pass(x, last_page_visited = None, context = ""):
 # returns a boolean that says whether we've found a backlinks section (if yes, then we should stop scanning the page that contains us)
+    global links, all_visited_pages
     new_last_page_visited = last_page_visited
     if not hasattr(x, 'title'):
         # visiting a block/page with no title.
-        return False
+        return {"found_backlinks_section" : False}
     log.info(f"  x [{x.id}] {x.title}")
     is_page = (x.type == "page")
     if is_page: # we're visiting a page. Make sure to change the last_page_visited and to denote that we found a new link
         if last_page_visited is not None:
-            links.add((last_page_visited["title"], last_page_visited["id"], x.title, x.id))
+            links.add((last_page_visited["title"], last_page_visited["id"], x.title, x.id, context))
             log.debug(f"   link found from ", {last_page_visited["title"]}, " to ", {x.title})
         new_last_page_visited = {"title" : x.title, "id" : x.id}
-    if x.id in already_visited:
-        return False
-    already_visited.add(x.id)
+    if x.id in all_visited_pages:
+        return {"found_backlinks_section" : False}
+    all_visited_pages.add(x.id)
     if x.title.startswith(notion_backlink_section):
         # found backlinks section. going up and skipping rest of page.
-        return True
+        return {"found_backlinks_section" : True}
     # looking for links to other notion pages in this block's title:
     if x.get("properties") is not None:
         for snippet in x.get("properties")["title"]:
             if snippet[0] == "‣": # found link
                 linked_node_id = snippet[1][0][1]
                 linked_block = client.get_block(linked_node_id)
-                recursive_pass(linked_block, new_last_page_visited)
+                recursive_pass(linked_block, last_page_visited = new_last_page_visited, context = x.title)
     # now visiting all the block's children:
     for child in x.children:
-        found_backlinks_section = recursive_pass(child, new_last_page_visited)
+        returned_info = recursive_pass(child, new_last_page_visited)
+        found_backlinks_section = returned_info["found_backlinks_section"]
         if found_backlinks_section: # found backlinks section so should stop scanning the page
             if is_page: # great, the backlinks section is the end of this page
-                return False
+                return {"found_backlinks_section" : False}
             else: # go back to the containing page
-                return True            
-    return False
+                return {"found_backlinks_section" : True}
+    return {"found_backlinks_section" : False}
 # Run the recursive function:
 # Store all page links within collection (tuples: from.name, from.id, to.name, to.id)
 links = set()
-already_visited = set()
+all_visited_pages = set()
 for block in cv.collection.get_rows():
     recursive_pass(block)
 #Inform what we have found
 print(f"  links found: {len(links)}")
 
-#Function for testing link's mutual pair in the links collection
-def hasPair(link, links):
-    for pair in links:
-        if pair[3] == link[1] and pair[1] == link[3]:
-            return True
-    return False
-
-#Store all mutual page links we have to create (tuples: from.name, from.id, to.name, to.id)
-links_to_make = []
-
-#LOOKING FOR LINKS WITHOUT MUTUAL LINKS
-for link in links:
-    if not hasPair(link, links):
-        links_to_make.append(link)
-        log.debug(f"  no mutual link from {link[0]} to {link[2]}")
+links_to_make = list(links)
 
 #Inform if we have no backlink to create at all
 if not len(links_to_make):
@@ -121,25 +109,14 @@ if not len(links_to_make):
 #Sort backlinks by source page (not really needed yet)
 links_to_make.sort(key=lambda item: item[3])
 
-print(f"  creating {len(links_to_make)} backlink(s) - please wait")
+def find_backlinks_section(page_id):
+    page = client.get_block(page_id)
 
-#Set style for new backlinks section name
-backlink_styles = {"H1": HeaderBlock, "H2": SubheaderBlock, "H3": SubsubheaderBlock, "TEXT": TextBlock}
-backlink_style = backlink_styles[config.get('notion', 'backlink_style')]
-
-#Iterating all backlinks to create
-for link in links_to_make:
-    page = client.get_block(link[3])
-    log.info(f"    seeking place to backlink {page.title} to {link[0]}")
-    
     backlinks_found = False
     last_backlink = None
-    
+
     #Iterating over all page sections
     for child in page.children:
-        log.debug(f"    inside child {getattr(child, 'title', child.type)}")
-        
-        #Set last known page element
         if last_backlink is None or not backlinks_found:
             last_backlink = child
 
@@ -153,9 +130,49 @@ for link in links_to_make:
         if backlinks_found and child.type == 'page':
             last_backlink = child
             continue
+    if backlinks_found:
+        return last_backlink
+    else:
+        return None
+    
 
+#Sort backlinks by source page (not really needed yet)
+links_to_make.sort(key=lambda item: item[3])
+
+#Set style for new backlinks section name
+backlink_styles = {"H1": HeaderBlock, "H2": SubheaderBlock, "H3": SubsubheaderBlock, "TEXT": TextBlock}
+backlink_style = backlink_styles[config.get('notion', 'backlink_style')]
+
+all_visited_pages_no_hyphens = [x.replace("-", "") for x in all_visited_pages]
+
+# First remove a lot of banklinks, namely all backlinks to pages that we visited (if they should still be in, they'll get added in the next phase) as well as backlinks to pages that don't exist anymore. But keep all banklinks to pages that we haven't visited.
+for page_id in all_visited_pages:
+    page = client.get_block(page_id)
+    last_backlink = find_backlinks_section(page_id)
+    if last_backlink is None:
+        continue
+    started_backlinks_section = False
+    list_of_children = last_backlink.children[:]
+    removed_all_backlinks = True
+    for child in list_of_children:
+        backlink_whole_text = child.title
+        only_backlink = backlink_whole_text[backlink_whole_text.find("notion.so/")+10:-2]
+        if only_backlink in all_visited_pages_no_hyphens:
+            child.remove()
+        else:
+            removed_all_backlinks = False
+    if removed_all_backlinks:
+        last_backlink.remove()
+
+print(f"  creating {len(links_to_make)} backlink(s) - please wait")
+
+# Now add all needed backlinks: (code below is very inefficient. can improve a lot but sorting in advance and changing to a depth-3 dictionary.)
+
+for backlink_source_page in {link[3] for link in links_to_make}:
+    page = client.get_block(backlink_source_page)
+    last_backlink = find_backlinks_section(backlink_source_page)
     #There were no backlinks section, adding one            
-    if not backlinks_found:
+    if last_backlink is None:
         log.debug(f"     {notion_backlink_section} section not found, adding")
         #We add empty space before backlinks section
         new_space_block = page.children.add_new(TextBlock, title="")
@@ -163,10 +180,20 @@ for link in links_to_make:
         new_backlink_block = page.children.add_new(backlink_style, title=notion_backlink_section)
         new_backlink_block.move_to(new_space_block, "after")
         last_backlink = new_backlink_block
-
-    #Actually creating the backlink
-    url_in_backlink = client.get_block(link[1]).get_browseable_url()
-    new_block = page.children.add_new(TextBlock, title="[{}]({})".format(link[0], url_in_backlink))
-    print(f"    created backlink from {link[2]} to {link[0]}")
+    for backlink_target_page_id, backlink_target_page_title in {(link[1], link[0]) for link in links_to_make if link[3] == backlink_source_page}:
+        log.info(f"going to backlink {page.title} to {backlink_target_page_title}")
+        url_in_backlink = client.get_block(backlink_target_page_id).get_browseable_url()
+        backlink_target_page_new_block = last_backlink.children.add_new(TextBlock, title="linked from [{}]({}).".format(backlink_target_page_title, url_in_backlink))
+        for link in links_to_make:
+            if link[3] != backlink_source_page: # only add links from the backlink_source_page
+                continue
+            if link[1] != backlink_target_page_id: # only add links from the backlink_source_page
+                continue
+            if link[4] is None or len(link[4].strip()) <= 1:
+                continue                
+            new_block = backlink_target_page_new_block.children.add_new(TextBlock, title=link[4])
+            # TODO: add to the context the inline link mention/link-title. right now it's being dropped.
+        print(f"    created backlinks from {link[2]} to {link[0]}")
 
 print(f"Finished.")
+


### PR DESCRIPTION
I made the forward-link scanner look not only at top-level links, but recursively inside, including subpages and really any page that can be reached from the original collected. This is much closer to how Roam Research works.

IMPORTANT NOTE: the new code will go outside of just the target collection. thus, this script is more risky than the original version! (But more powerful.)

BTW, I think my pull request is along the lines of [the suggestion here](https://github.com/twkrol/notion-backlinks-creator/issues/1#issue-650735459)

**Update (August 10):** I'm working on expanding the script in many ways, to be similar to the functionality of Roam. will open a PR when I'm done. 